### PR TITLE
fix: Correct bundler command typo in Rails image test

### DIFF
--- a/.github/workflows/build-rails-images.yml
+++ b/.github/workflows/build-rails-images.yml
@@ -163,4 +163,4 @@ jobs:
         run: |
           docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }} ruby -v
           docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }} sh -c 'gem list rails && rails -v'
-          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }} bundle -v
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }} bundler -v


### PR DESCRIPTION
## Summary
- Fixed typo in `build-rails-images.yml` where `bundle -v` was incorrectly used instead of `bundler -v`
- This typo was causing all Rails-specific Docker image builds to fail with exit code 127 (command not found)

## Problem
The test step in the Rails image workflow was using the non-existent `bundle` command instead of the correct `bundler` command on line 166.

## Solution
Changed `bundle -v` to `bundler -v` to match the actual command installed in the Docker image.

## Test plan
- [x] Fixed the typo in the workflow file
- [x] Validated YAML syntax with yamllint
- [ ] CI builds should now pass for Rails-specific Docker images

🤖 Generated with [Claude Code](https://claude.com/claude-code)