### PR TITLE
fix: GitHub Actions split function error and Hadolint warnings

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,9 +17,9 @@ on:
   workflow_dispatch:
     inputs:
       ruby_versions:
-        description: 'Ruby versions to build (comma-separated, e.g., "3.2.9,3.3.10,3.4.7")'
+        description: 'Ruby versions to build (JSON array, e.g., ["3.2.9","3.3.10","3.4.7"])'
         required: false
-        default: '3.2.9,3.3.10,3.4.7'
+        default: '["3.2.9","3.3.10","3.4.7"]'
       platforms:
         description: 'Platforms to build for'
         required: false
@@ -44,7 +44,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        ruby-version: ${{ fromJson(github.event.inputs.ruby_versions && format('["{0}"]', join(split(github.event.inputs.ruby_versions, ','), '", "')) || '["3.2.9", "3.3.10", "3.4.7"]') }}
+        ruby-version: ${{ fromJson(github.event.inputs.ruby_versions || '["3.2.9", "3.3.10", "3.4.7"]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV TZ=UTC
 # -----------------------------------------------------------
 # System packages (multi-arch friendly + Chromium compatible)
 # -----------------------------------------------------------
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   curl \
   wget \
@@ -98,17 +98,12 @@ RUN gem install \
   pg
 
 # -----------------------------------------------------------
-# Pre-create directories
-# -----------------------------------------------------------
-RUN mkdir -p /app /tmp/cache
-WORKDIR /app
-
-# -----------------------------------------------------------
-# Bootsnap cache directory for CI
+# Pre-create directories and Bootsnap cache
 # -----------------------------------------------------------
 # Bootsnap speeds up Ruby boot time by caching expensive operations
 # Setting a CI-specific directory prevents cache conflicts between builds
-RUN mkdir -p /app/tmp/bootsnap-ci
+RUN mkdir -p /app /tmp/cache /app/tmp/bootsnap-ci
+WORKDIR /app
 ENV BOOTSNAP_CACHE_DIR=/app/tmp/bootsnap-ci
 
 # -----------------------------------------------------------

--- a/Dockerfile.lean
+++ b/Dockerfile.lean
@@ -13,7 +13,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Install only essential system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   # Build essentials
   build-essential \
   git \

--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -19,7 +19,7 @@ ENV TZ=UTC
 # -----------------------------------------------------------
 # System packages (multi-arch compatible)
 # -----------------------------------------------------------
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     wget \


### PR DESCRIPTION
## Summary

This PR fixes critical CI issues:
1. GitHub Actions workflow error due to unsupported `split` function
2. Hadolint warnings in Dockerfiles

## Issues Fixed

### 1. GitHub Actions Split Function Error
**Problem**: `split` function doesn't exist in GitHub Actions expressions
**Solution**: Changed ruby_versions input from comma-separated to JSON array format

Before: `ruby_versions: "3.2.9,3.3.10,3.4.7"`
After: `ruby_versions: ["3.2.9","3.3.10","3.4.7"]`

### 2. Hadolint Warnings
Fixed the following Dockerfile issues:
- **DL3015**: Added `--no-install-recommends` to all `apt-get install` commands
- **DL3059**: Consolidated multiple `RUN mkdir` instructions in main Dockerfile
- **DL3028**: Intentionally not pinning gem versions (we want latest for CI)

## Changes
- Modified `.github/workflows/build-and-publish.yml` to use JSON array input
- Added `--no-install-recommends` to all three Dockerfiles
- Consolidated directory creation in main Dockerfile

## Testing
- Dockerfiles build successfully locally
- Hadolint warnings reduced from 4 to 1 (gem pinning intentionally skipped)
- Workflow syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)