### PR TITLE
Fix Rails installation to be globally accessible

### DIFF
--- a/Dockerfile.rails
+++ b/Dockerfile.rails
@@ -107,12 +107,20 @@ RUN RAILS_MAJOR_MINOR=$(echo ${RAILS_VERSION} | cut -d. -f1-2) && \
     rm -rf /tmp/Gemfile.rails-*
 
 # -----------------------------------------------------------
-# Install gems from version-specific Gemfile
+# Install Rails directly via gem first
+# -----------------------------------------------------------
+# Install Rails directly so it's available globally without bundle exec
+RUN gem install rails -v ${RAILS_VERSION}
+
+# -----------------------------------------------------------
+# Install other gems from version-specific Gemfile
 # -----------------------------------------------------------
 RUN bundle install --jobs 4 --retry 3
 
-# Verify Rails is installed and accessible
-RUN echo "Rails version:" && \
+# Verify Rails is installed and accessible (both ways)
+RUN echo "Rails version (direct):" && \
+    rails --version && \
+    echo "Rails version (bundled):" && \
     bundle exec rails --version && \
     echo "Installed gems:" && \
     bundle list | grep -E "(rails|propshaft|turbo|stimulus)"


### PR DESCRIPTION
## Summary
- Fixed Rails Docker image build failure where `rails -v` was failing
- Rails is now installed directly via gem in addition to bundler
- Ensures the rails command is globally accessible without requiring bundle exec

## Problem
The GitHub Actions test step was failing because it tried to run `rails -v` directly, but Rails was only installed via bundler (making it accessible only through `bundle exec rails`).

## Solution
Modified `Dockerfile.rails` to install Rails directly via gem first, then let bundler install the remaining dependencies. This ensures:
1. The `rails` command is available globally 
2. All bundler dependencies are still properly installed
3. Both `rails -v` and `bundle exec rails -v` work correctly

## Test plan
- [x] Built Docker image locally with Ruby 3.2.9 and Rails 7.2.3
- [x] Verified `rails -v` works directly
- [x] Verified `bundle exec rails -v` still works
- [x] Confirmed all Rails-related gems are properly installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)