### PR TITLE
fix: Use PR workflow for TAGS.md updates instead of direct push

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -101,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -127,12 +128,18 @@ jobs:
           - \`ghcr.io/tastybamboo/panda-ci:ruby-3.2-${DATE}\`
           EOF
 
-      - name: Commit updates
-        run: |
-          if [[ -n $(git status -s) ]]; then
-            git config --local user.email "actions@github.com"
-            git config --local user.name "GitHub Actions"
-            git add TAGS.md
-            git commit -m "Update available tags [skip ci]"
-            git push
-          fi
+      - name: Create Pull Request for TAGS update
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: Update available tags [skip ci]"
+          branch: automated/update-tags
+          delete-branch: true
+          title: "docs: Update available tags"
+          body: |
+            ## Automated TAGS.md Update
+
+            Updated the available Docker image tags list.
+
+            ---
+            *This PR was automatically generated after a successful image build.*


### PR DESCRIPTION
## Summary

- Changed the `update-readme` job to use `peter-evans/create-pull-request` instead of pushing directly to main
- Added `pull-requests: write` permission to the job

## Why

The `update-readme` job was failing because it tried to push directly to main, which is blocked by branch protection rules. See [failed run](https://github.com/tastybamboo/ci-tooling/actions/runs/20367759452/job/58527161359).

## Test plan

- [x] Workflow passes yamllint validation
- [ ] Next build on main triggers a PR creation for TAGS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)