### PR TITLE
fix: Use bundle config instead of deprecated --path flag

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -182,7 +182,7 @@ jobs:
           echo "Testing bundle install and rake execution..."
           docker run --rm -v $(pwd)/test-app:/test-app -w /test-app \
             test-image:${{ matrix.dockerfile }} \
-            sh -c "bundle install --path vendor/bundle && bundle exec rake --version"
+            sh -c "bundle config set --local path vendor/bundle && bundle install && bundle exec rake --version"
 
       # ============================================================
       # Image size reporting


### PR DESCRIPTION
## Summary

- Replaces deprecated `bundle install --path vendor/bundle` with `bundle config set --local path vendor/bundle && bundle install`

## Why

The `--path` flag is deprecated in Bundler 2.x and conflicts with the global `BUNDLE_PATH` config set in the Dockerfiles. This was causing exit code 15 failures in the "Test bundle install and rake execution" step.

## Test plan

- [ ] CI passes on this PR
- [ ] Merge this first, then re-run CI on PRs #10 and #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)