### PR TITLE
feat: Add concurrency controls to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,6 +36,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: tastybamboo/panda-ci
 
+concurrency:
+  group: ${{ github.event_name == 'schedule' && 'build-ruby-scheduled' || format('build-ruby-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-rails-images.yml
+++ b/.github/workflows/build-rails-images.yml
@@ -17,6 +17,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: tastybamboo/panda-ci
 
+concurrency:
+  group: ${{ github.event_name == 'schedule' && 'build-rails-scheduled' || format('build-rails-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
 jobs:
   build-rails-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-rails-updates.yml
+++ b/.github/workflows/check-rails-updates.yml
@@ -12,6 +12,10 @@ permissions:
   pull-requests: write
   actions: write
 
+concurrency:
+  group: check-rails-updates
+  cancel-in-progress: true
+
 jobs:
   check-rails-updates:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -12,6 +12,10 @@ permissions:
   pull-requests: write
   actions: write
 
+concurrency:
+  group: check-ruby-bundler-updates
+  cancel-in-progress: true
+
 jobs:
   check-updates:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,6 +10,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  group: pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ============================================================
   # YAML Validation


### PR DESCRIPTION
## Summary

Adds concurrency controls to all 5 GitHub Actions workflows to automatically cancel previous CI jobs when new ones are pushed to the same branch.

- ✅ PR validation: per-branch cancellation for rapid commits
- ✅ Build workflows: conditional cancellation protecting scheduled multi-arch builds  
- ✅ Update checkers: global cancellation (only latest check matters)

## Benefits

- Faster PR feedback (stale builds cancelled)
- Reduced resource usage
- Weekly multi-arch builds protected from cancellation

## Changes Made

### 1. `.github/workflows/pr-validation.yml`
Per-branch concurrency control - each PR/branch gets independent groups.

### 2. `.github/workflows/build-and-publish.yml`
Conditional cancellation - protects weekly scheduled builds while cancelling stale push/PR builds.

### 3. `.github/workflows/build-rails-images.yml`
Same pattern as build-and-publish - separate group for scheduled vs on-demand builds.

### 4. `.github/workflows/check-updates.yml`
Global concurrency control - only latest Ruby/Bundler update check matters.

### 5. `.github/workflows/check-rails-updates.yml`
Global concurrency control - only latest Rails update check matters.

## Test plan

- [ ] Push 2 rapid commits to a PR, verify first workflow is cancelled
- [ ] Trigger manual build twice, verify first is cancelled
- [ ] Verify scheduled builds continue uninterrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)