### PR TITLE
fix(ci): don't cancel sibling image builds when one job fails

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -80,6 +80,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ${{ fromJson(needs.resolve-versions.outputs.versions) }}
     steps:

--- a/.github/workflows/build-rails-images.yml
+++ b/.github/workflows/build-rails-images.yml
@@ -47,6 +47,7 @@ jobs:
       packages: write
 
     strategy:
+      fail-fast: false
       matrix:
         include: ${{ fromJson(needs.resolve-matrix.outputs.matrix) }}
 


### PR DESCRIPTION
## Summary

Add `fail-fast: false` to both image build matrices. In the post-merge run of #19, a transient GitHub Actions cache-service DNS timeout failed one `build-rails-images` job and the default fail-fast behaviour cancelled the other 15 — the image builds are independent, so each should succeed or fail on its own (this matters most for the unattended weekly rebuilds).

No other changes.